### PR TITLE
remove vocab_size+1 for encoder & decoder

### DIFF
--- a/mxwrap/seq2seq/decoder.py
+++ b/mxwrap/seq2seq/decoder.py
@@ -52,7 +52,7 @@ class LstmDecoder(object):
         assert (len(last_states) == self.num_of_layer)
 
         # embedding layer
-        embed = mx.sym.Embedding(data=data, input_dim=self.vocab_size + 1,
+        embed = mx.sym.Embedding(data=data, input_dim=self.vocab_size,
                                  weight=embed_weight, output_dim=self.embed_dim, name='target_embed')
         wordvec = mx.sym.SliceChannel(data=embed, num_outputs=self.seq_len, squeeze_axis=1)
         # split mask
@@ -177,7 +177,7 @@ class LstmAttentionDecoder(object):
         assert (len(last_states) == self.num_of_layer)
 
         # embedding layer
-        embed = mx.sym.Embedding(data=data, input_dim=self.vocab_size + 1,
+        embed = mx.sym.Embedding(data=data, input_dim=self.vocab_size,
                                  weight=embed_weight, output_dim=self.embed_dim, name='target_embed')
         wordvec = mx.sym.SliceChannel(data=embed, num_outputs=self.seq_len, squeeze_axis=1)
         # split mask
@@ -324,7 +324,7 @@ class GruAttentionDecoder(object):
         assert (len(last_states) == self.num_of_layer)
 
         # embedding layer
-        embed = mx.sym.Embedding(data=data, input_dim=self.vocab_size + 1,
+        embed = mx.sym.Embedding(data=data, input_dim=self.vocab_size,
                                  weight=embed_weight, output_dim=self.embed_dim, name='target_embed')
         wordvec = mx.sym.SliceChannel(data=embed, num_outputs=self.seq_len, squeeze_axis=1)
         # split mask

--- a/mxwrap/seq2seq/encoder.py
+++ b/mxwrap/seq2seq/encoder.py
@@ -38,7 +38,7 @@ class LstmEncoder(object):
         assert (len(last_states) == self.num_of_layer)
 
         # embedding layer
-        embed = mx.sym.Embedding(data=data, input_dim=self.vocab_size + 1,
+        embed = mx.sym.Embedding(data=data, input_dim=self.vocab_size,
                                  weight=embed_weight, output_dim=self.embed_dim, name='source_embed')
         wordvec = mx.sym.SliceChannel(data=embed, num_outputs=self.seq_len, squeeze_axis=1)
 
@@ -125,7 +125,7 @@ class BiDirectionalLstmEncoder(object):
         assert (len(backward_last_states) == self.num_of_layer)
 
         # embedding layer
-        embed = mx.sym.Embedding(data=data, input_dim=self.vocab_size + 1,
+        embed = mx.sym.Embedding(data=data, input_dim=self.vocab_size,
                                  weight=embed_weight, output_dim=self.embed_dim, name='source_embed')
         wordvec = mx.sym.SliceChannel(data=embed, num_outputs=self.seq_len, squeeze_axis=1)
 
@@ -263,7 +263,7 @@ class BiDirectionalGruEncoder(object):
         assert (len(backward_last_states) == self.num_of_layer)
 
         # embedding layer
-        embed = mx.sym.Embedding(data=data, input_dim=self.vocab_size + 1,
+        embed = mx.sym.Embedding(data=data, input_dim=self.vocab_size,
                                  weight=embed_weight, output_dim=self.embed_dim, name='source_embed')
         wordvec = mx.sym.SliceChannel(data=embed, num_outputs=self.seq_len, squeeze_axis=1)
 

--- a/nmt/inference.py
+++ b/nmt/inference.py
@@ -180,7 +180,7 @@ def lstm_attention_decode_symbol(t_num_lstm_layer, t_seq_len, t_vocab_size, t_nu
     assert (len(last_states) == t_num_lstm_layer)
 
     hidden = mx.sym.Embedding(data=data,
-                              input_dim=t_vocab_size + 1,
+                              input_dim=t_vocab_size,
                               output_dim=t_num_embed,
                               weight=embed_weight,
                               name="target_embed")

--- a/nmt/inference_mask.py
+++ b/nmt/inference_mask.py
@@ -186,7 +186,7 @@ def lstm_attention_decode_symbol(t_num_lstm_layer, t_seq_len, t_vocab_size, t_nu
     assert (len(last_states) == t_num_lstm_layer)
 
     hidden = mx.sym.Embedding(data=data,
-                              input_dim=t_vocab_size + 1,
+                              input_dim=t_vocab_size,
                               output_dim=t_num_embed,
                               weight=embed_weight,
                               name="target_embed")


### PR DESCRIPTION
If I didn't misunderstand, since we already add `vocab_size` by 1 at
https://github.com/magic282/MXNMT/blob/master/nmt/xsymbol.py#L34
and
https://github.com/magic282/MXNMT/blob/master/nmt/tester.py#L23
there's no need to do this again for Embedding layers.

I tested and it worked.